### PR TITLE
Two fixes in Button

### DIFF
--- a/src/components/Button/Button.styled.tsx
+++ b/src/components/Button/Button.styled.tsx
@@ -18,6 +18,10 @@ export const ButtonStyled = styled.button`
     transition          : all 0.2s;
     background-position : center;
     user-select         : none;
+    
+    > * {
+      all: unset;
+    }
 
     &.primary {
         background-color : ${(props: ButtonProps) => props.theme.button.primary.default.bg};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { ButtonStyled } from "./Button.styled"
 import { ButtonProps, ButtonElementType } from "./constants";
 
 export const Button = ({ size, shape, shadow, border, kind, isLoading, hasDelete, className, ...props }: ButtonProps) => {
-    const classNames = [className];
+    let classNames = [];
 
     if (className) {
         classNames.push(className);


### PR DESCRIPTION
1. Unsets all styles for children of Button (useful when using router `<Link>` inside `<Button>`)
2. Fixes the class name duplication bug